### PR TITLE
Stacktrace is not shown when giving wrong command

### DIFF
--- a/bin/pubx.dart
+++ b/bin/pubx.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:args/command_runner.dart';
 import 'package:pubx/pubx.dart';
 
@@ -6,5 +8,11 @@ main(List<String> arguments) {
     ..addCommand(SearchCommand())
     ..addCommand(ViewCommand());
 
-  runner.run(arguments);
+  runner.run(arguments).catchError(
+          (error) {
+            if (error is! UsageException) throw error;
+            print(error);
+            exit(64);
+          }
+  );
 }

--- a/bin/pubx.dart
+++ b/bin/pubx.dart
@@ -3,16 +3,19 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:pubx/pubx.dart';
 
-main(List<String> arguments) {
+main(List<String> arguments) async {
   final runner = CommandRunner("pubx", "The missing pub commands.")
     ..addCommand(SearchCommand())
     ..addCommand(ViewCommand());
 
-  runner.run(arguments).catchError(
-          (error) {
-            if (error is! UsageException) throw error;
-            print(error);
-            exit(64);
-          }
-  );
+  try {
+    await runner.run(arguments);
+  } on UsageException catch (e) {
+    print(e);
+    exit(64);
+  } catch(e) {
+    print("An unknown error has occured.");
+    print(runner.usage);
+    rethrow;
+  }
 }


### PR DESCRIPTION
Do not show the stacktrace when giving a wrong command

Changed so that the output is of format:

```
$ dart ./bin/pubx.dart asdasd
Could not find a command named "asdasd".

Usage: pubx <command> [arguments]

Global options:
-h, --help    Print this usage information.

Available commands:
  help     Display help information for pubx.
  search   Searches pub.dev for packages
  view     View information about a pub.dev package

Run "pubx help <command>" for more information about a command.

```