### PR TITLE
add command to show pkgs with updates available

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Searches [pub.dev](https://pub.dev).
 
 `pubx search {query}`
 
-### view
+### updates
 
-*Aliases: updates, u*
+*Aliases: u*
 
 Checks pub.dev for packages in your pubspec that have updated versions
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Searches [pub.dev](https://pub.dev).
 
 ### view
 
+*Aliases: updates, u*
+
+Checks pub.dev for packages in your pubspec that have updated versions
+
+`pubx updates`
+
+### view
+
 *Aliases: info, show, v*
 
 Displays information about the specified package.

--- a/bin/pubx.dart
+++ b/bin/pubx.dart
@@ -8,6 +8,7 @@ void main(List<String> arguments) async {
     ..addCommand(AddCommand())
     ..addCommand(SearchCommand())
     ..addCommand(ViewCommand())
+    ..addCommand(UpdatesCommand())
     ..addCommand(WhichCommand());
 
   try {

--- a/lib/src/commands/commands.dart
+++ b/lib/src/commands/commands.dart
@@ -1,4 +1,5 @@
 export 'add.dart';
 export 'search.dart';
 export 'view.dart';
+export 'updates.dart';
 export 'which.dart';

--- a/lib/src/commands/updates.dart
+++ b/lib/src/commands/updates.dart
@@ -31,12 +31,14 @@ class UpdatesCommand extends Command {
     final YamlMap dependencies = pubYaml['dependencies'];
 
     dependencies.keys.forEach((packageName) async {
-      try {
-        final pkgInfo = await fetchPackageInfo(packageName);
-        print(
-            '${pkgInfo.name} [${dependencies[packageName]}]  latest: ${pkgInfo.version}');
-      } catch (e) {
-        //NA
+      if (!dependencies[packageName].toString().startsWith('{sdk:')) {
+        try {
+          final pkgInfo = await fetchPackageInfo(packageName);
+          print(
+              '${pkgInfo.name} [${dependencies[packageName]}]  latest: ${pkgInfo.version}');
+        } catch (e) {
+          //NA
+        }
       }
     });
   }

--- a/lib/src/commands/updates.dart
+++ b/lib/src/commands/updates.dart
@@ -34,7 +34,7 @@ class UpdatesCommand extends Command {
       try {
         final pkgInfo = await fetchPackageInfo(packageName);
         print(
-            '${pkgInfo.name}\t[${dependencies[packageName]}]\t\latest: ${pkgInfo.version}');
+            '${pkgInfo.name} [${dependencies[packageName]}]  latest: ${pkgInfo.version}');
       } catch (e) {
         //NA
       }

--- a/lib/src/commands/updates.dart
+++ b/lib/src/commands/updates.dart
@@ -30,16 +30,16 @@ class UpdatesCommand extends Command {
 
     final YamlMap dependencies = pubYaml['dependencies'];
 
-    dependencies.keys.forEach((packageName) async {
+    for (final packageName in dependencies.keys) {
       if (!dependencies[packageName].toString().startsWith('{sdk:')) {
         try {
           final pkgInfo = await fetchPackageInfo(packageName);
           print(
-              '${pkgInfo.name} [${dependencies[packageName]}]  latest: ${pkgInfo.version}');
+              '${pkgInfo.name} \t [${dependencies[packageName]}] \t latest: ${pkgInfo.version}');
         } catch (e) {
           //NA
         }
       }
-    });
+    }
   }
 }

--- a/lib/src/commands/updates.dart
+++ b/lib/src/commands/updates.dart
@@ -31,9 +31,13 @@ class UpdatesCommand extends Command {
     final YamlMap dependencies = pubYaml['dependencies'];
 
     dependencies.keys.forEach((packageName) async {
-      final pkgInfo = await fetchPackageInfo(packageName);
-      print(
-          '${pkgInfo.name}\t[${dependencies[packageName]}]\t\latest: ${pkgInfo.version}');
+      try {
+        final pkgInfo = await fetchPackageInfo(packageName);
+        print(
+            '${pkgInfo.name}\t[${dependencies[packageName]}]\t\latest: ${pkgInfo.version}');
+      } catch (e) {
+        //NA
+      }
     });
   }
 }

--- a/lib/src/commands/updates.dart
+++ b/lib/src/commands/updates.dart
@@ -1,0 +1,39 @@
+import 'package:args/command_runner.dart';
+import 'package:yaml/yaml.dart';
+
+import '../api.dart';
+import '../pubspec.dart';
+
+class UpdatesCommand extends Command {
+  @override
+  final String name = 'updates';
+
+  @override
+  final List<String> aliases = ['u'];
+
+  @override
+  final String description =
+      'Checks pub.dev for packages in your pubspec that have updated versions';
+
+  @override
+  final String invocation = 'pubx updates';
+
+  Future<void> run() async {
+    final pub = findPubspec();
+
+    // Load and parse pubspec.yaml
+    final pubContents = await pub.readAsStringSync();
+    final pubYaml = loadYaml(
+      pubContents,
+      sourceUrl: pub.uri,
+    ) as YamlMap;
+
+    final YamlMap dependencies = pubYaml['dependencies'];
+
+    dependencies.keys.forEach((packageName) async {
+      final pkgInfo = await fetchPackageInfo(packageName);
+      print(
+          '${pkgInfo.name}\t[${dependencies[packageName]}]\t\latest: ${pkgInfo.version}');
+    });
+  }
+}

--- a/lib/src/commands/updates.dart
+++ b/lib/src/commands/updates.dart
@@ -30,12 +30,21 @@ class UpdatesCommand extends Command {
 
     final YamlMap dependencies = pubYaml['dependencies'];
 
-    for (final packageName in dependencies.keys) {
+    final packageNames = dependencies.keys.cast<String>();
+    final maxPackageNameLength = packageNames.fold(
+        0,
+        (int maxLength, String name) =>
+            name.length > maxLength ? name.length : maxLength);
+
+    for (final packageName in packageNames) {
       if (!dependencies[packageName].toString().startsWith('{sdk:')) {
         try {
           final pkgInfo = await fetchPackageInfo(packageName);
+          String currentVersion = dependencies[packageName].toString();
+          currentVersion =
+              currentVersion.startsWith('{git:') ? 'git repo' : currentVersion;
           print(
-              '${pkgInfo.name} \t [${dependencies[packageName]}] \t latest: ${pkgInfo.version}');
+              '${pkgInfo.name.padRight(maxPackageNameLength)} \t [$currentVersion] \t latest: ${pkgInfo.version}');
         } catch (e) {
           //NA
         }


### PR DESCRIPTION
This PR adds a command that will list for all the dependencies in the local pubspec.yaml the current packages and the latest available on pub.dev to quickly give a summary of which packages have updated versions available:

```
dart bin/pubx.dart u
http    [^0.12.0]       latest: 0.12.0+2
path    [^1.6.0]        latest: 1.6.4
yaml    [^2.1.16]       latest: 2.1.16
quiver  [^2.0.4]        latest: 2.0.5
args    [^1.5.0]        latest: 1.5.2
```

