### PR TITLE
Use package for column output

### DIFF
--- a/lib/src/commands/updates.dart
+++ b/lib/src/commands/updates.dart
@@ -50,7 +50,8 @@ class UpdatesCommand extends Command {
           data.add(
               [pkgInfo.name, currentVersion, 'latest: ${pkgInfo.version}']);
         } catch (e) {
-          //NA
+          print(
+              'There was a problem fetching dependency information for your project');
         }
       }
     }

--- a/lib/src/commands/updates.dart
+++ b/lib/src/commands/updates.dart
@@ -1,4 +1,5 @@
 import 'package:args/command_runner.dart';
+import 'package:dolumns/dolumns.dart';
 import 'package:yaml/yaml.dart';
 
 import '../api.dart';
@@ -31,11 +32,8 @@ class UpdatesCommand extends Command {
     final YamlMap dependencies = pubYaml['dependencies'];
 
     final packageNames = dependencies.keys.cast<String>();
-    final maxPackageNameLength = packageNames.fold(
-        0,
-        (int maxLength, String name) =>
-            name.length > maxLength ? name.length : maxLength);
 
+    final data = <List<String>>[];
     for (final packageName in packageNames) {
       bool isSDK = false;
       String pkgType;
@@ -49,13 +47,14 @@ class UpdatesCommand extends Command {
 
           String currentVersion = dependencies[packageName].toString();
           currentVersion = pkgType ?? currentVersion;
-          print(
-              '${pkgInfo.name.padRight(maxPackageNameLength)} \t [$currentVersion] \t latest: ${pkgInfo.version}');
+          data.add(
+              [pkgInfo.name, currentVersion, 'latest: ${pkgInfo.version}']);
         } catch (e) {
           //NA
         }
       }
     }
+    print(dolumnify(data));
   }
 
   bool _isSdkPackage(YamlMap package) => package['sdk'] != null;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -64,6 +64,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.16.1"
+  dolumns:
+    dependency: "direct main"
+    description:
+      name: dolumns
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1+1"
   front_end:
     dependency: transitive
     description:
@@ -352,4 +359,4 @@ packages:
     source: hosted
     version: "2.1.16"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
+  dart: ">=2.7.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   path: ^1.6.0
   quiver: ^2.0.4
   yaml: ^2.1.16
+  dolumns: ^1.0.1+1
 
 dev_dependencies:
   pedantic: ^1.7.0


### PR DESCRIPTION
I realised that text column outputs would be useful for other projects, so I created a separate package to handle that and so this PR changes the update command code to use that instead. The `dolumn` package also improves the output in some cases by not relying on using tabs.